### PR TITLE
refactor(ProgressBar): use early returns in mouse move handler

### DIFF
--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -26,17 +26,18 @@ export default class ProgressBar extends Component {
   }
 
   mouseMoveHandler = event => {
-    if (this.isDragging  === true) {
-      const parentPosition = this.bar.offsetLeft;
-      const parentWidth = this.bar.getBoundingClientRect().width;
-      event = event || window.event;
-      const dragX = event.pageX;
-      const offset = (dragX - parentPosition) <= 300 ? dragX - parentPosition : parentWidth
-      this.setState({
-        offset
-      });
-      this.setBar();
+    if (!this.isDragging) {
+      return;
     }
+    const parentPosition = this.bar.offsetLeft;
+    const parentWidth = this.bar.getBoundingClientRect().width;
+    event = event || window.event;
+    const dragX = event.pageX;
+    const offset = (dragX - parentPosition) <= 300 ? dragX - parentPosition : parentWidth
+    this.setState({
+      offset
+    });
+    this.setBar();
   }
 
   render() {


### PR DESCRIPTION
Check [this link](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/Return-Early-Pattern).

It's a good habit to return as soon as you can. It helps you to avoid nesting blocks and makes your code more readable.

Also, there's no need to check a bool value like this:
```js
const x = true;

if (x === true)...
```

It's enough to do it like this:
```js
const x = true;

if (x)...
// or maybe
if (!x)...
```